### PR TITLE
Fix output split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,16 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
   take care of coordinate system changes, while forcing should return static
   fields.
 
-## [2.3.0] - 2026-08-03
+## [2.3.1] - 2026-08-03
+### Fixed
+- Output split now works also on continuous releases with infrequent writes
+
+
+## [2.3.0] - 2026-02-11
 ### Added
 - Warm start capabilities
 ### Changed
 - Skip forward if no particles
-### Fixed
-- Output split now works also on continuous releases with infrequent writes
-
-### Changed
 - Use sphinx autoapi to generate documentation
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
   take care of coordinate system changes, while forcing should return static
   fields.
 
-## [2.3.0] - unreleased
+## [2.3.0] - 2026-08-03
 ### Added
 - Warm start capabilities
 ### Changed
 - Skip forward if no particles
+### Fixed
+- Output split now works also on continuous releases with infrequent writes
 
 ### Changed
 - Use sphinx autoapi to generate documentation

--- a/ladim/__init__.py
+++ b/ladim/__init__.py
@@ -1,6 +1,6 @@
 """This is the main ladim module"""
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 __all__ = ['run', 'main']
 
 from .cli import main, run

--- a/ladim/output.py
+++ b/ladim/output.py
@@ -5,6 +5,7 @@ if typing.TYPE_CHECKING:
     from .model import Model
 import os
 import contextlib
+import abc
 
 
 class Output:
@@ -63,14 +64,27 @@ class Output:
         return Output(variables, file, frequency, numrec)
 
     def update(self, model: "Model"):
-        data_dict_init = self._update_init_vars(model)
+        # Check if this is a write step for instance (dynamic) variables
         data_dict_inst = self._update_instance_vars(model)
+        self.writer.write_instance(data_dict_inst)
 
-        self.writer.write(data_dict_init | data_dict_inst)
+        # Check if there are any new particles to write
+        # Do this after write_instance in case there is a file name rotation
+        data_dict_init = self._update_init_vars(model)
+        self.writer.write_init(data_dict_init)
 
     def _update_init_vars(self, model) -> dict[str, np.ndarray]:
         """
-        Update the initial state of new particles
+        Build output arrays for newly released particles only.
+
+        This method inspects how many particle-table rows have already been
+        written to the output and compares that with the cumulative number of
+        released particles in the model state. Any particles that have been
+        released but not yet written are treated as "new" and their initial
+        variables are returned as contiguous arrays ordered by pid offset.
+
+        Returns an empty dict when there are no new particles on this solver
+        step.
         """
 
         # Check if there are any new particles
@@ -97,7 +111,13 @@ class Output:
 
     def _update_instance_vars(self, model) -> dict[str, np.ndarray]:
         """
-        Update the current state of dynamic variables
+        Build one time-record payload for dynamic (instance) variables.
+
+        Instance variables are written at the configured output frequency,
+        not on every solver step. If the current solver time is not a write
+        time, this returns an empty dict. Otherwise it returns the per-particle
+        instance arrays plus the scalar time metadata fields (`time` and
+        `particle_count`) that define the ragged record.
         """
 
         # Check if this is a write time step
@@ -241,11 +261,10 @@ class Writer:
     """
     Abstract base class for output writers
 
-    An output writer should be able to write tabular data in a thread-safe
-    way to the output storage backend. The output may be in the form of one or
-    more tables, distributed over one or more files. Each write operation should
-    be atomic, i.e. all data is written sequentially to the file at once. The
-    total number of rows in each table is not known at creation time.
+    An output writer stores tabular particle data in one or more files.
+    Callers write initial (static) and instance (dynamic) data through
+    separate methods. Only ``write_instance`` advances the time-record
+    counter used for multi-file splitting (``numrec``).
 
     Each table may have a number of columns, each with a unique name, data type
     and potentially some metadata attributes. The number of columns and their
@@ -287,9 +306,26 @@ class Writer:
 
         return _MFNCWriter(file, formats, numrec, offset_variables, copy_dims)
 
-    def write(self, data: dict[str, np.ndarray]):
+    @abc.abstractmethod
+    def write_init(self, data: dict[str, np.ndarray]):
         """
-        Write data to file(s)
+        Append initial (static/particle-table) variables.
+
+        Does not count toward ``numrec`` file splitting. Empty ``data`` is a
+        no-op.
+
+        :param data: Dictionary with variable names as keys and numpy arrays as
+            data values
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def write_instance(self, data: dict[str, np.ndarray]):
+        """
+        Append one time record of instance (dynamic) variables.
+
+        Each non-empty call counts as one record for ``numrec`` file splitting.
+        Empty ``data`` is a no-op.
 
         :param data: Dictionary with variable names as keys and numpy arrays as
             data values
@@ -369,7 +405,16 @@ class _NCWriter(Writer):
     def paths(self) -> list[typing.Any]:
         return self._paths
 
-    def write(self, data: dict[str, np.ndarray]):
+    def write_init(self, data: dict[str, np.ndarray]):
+        if not data:
+            return
+        with _open_or_relay(self._paths[0], mode='a') as dset:
+            self._write(dset, data)
+            self._sizes = {k: v.size for k, v in dset.dimensions.items()}
+
+    def write_instance(self, data: dict[str, np.ndarray]):
+        if not data:
+            return
         with _open_or_relay(self._paths[0], mode='a') as dset:
             self._write(dset, data)
             self._sizes = {k: v.size for k, v in dset.dimensions.items()}
@@ -465,8 +510,22 @@ class _MFNCWriter(Writer):
     def paths(self) -> list[typing.Any]:
         return self._paths
 
-    def write(self, data: dict[str, np.ndarray]):
-        if not(self._step_counter % self.numrec):
+    def write_init(self, data: dict[str, np.ndarray]):
+        if not data:
+            return
+        if not self._paths:
+            self._initialize_next_file()
+
+        with _open_or_relay(self._paths[-1], mode='a') as dset:
+            self._write(dset, data)
+
+    def write_instance(self, data: dict[str, np.ndarray]):
+        if not data:
+            return
+
+        if not self._paths:
+            self._initialize_next_file()
+        elif self._step_counter > 0 and self._step_counter % self.numrec == 0:
             self._initialize_next_file()
 
         with _open_or_relay(self._paths[-1], mode='a') as dset:
@@ -481,11 +540,11 @@ class _MFNCWriter(Writer):
             sz = old_sizes[dimname]
             dset.variables[k][sz:sz + len(v)] = v
 
-        for k, v in self._offset_variables.items():
-            if v in dset.variables:
-                dset.variables[v][...] = self._offsets[k]
+        for dimname, varname in self._offset_variables.items():
+            if varname in dset.variables and dimname in self._offsets:
+                dset.variables[varname][...] = self._offsets[dimname]
 
-        self._sizes = {k: v.size + self._offsets[k] for k, v in dset.dimensions.items()}
+        self._sizes = {k: v.size + self._offsets.get(k, 0) for k, v in dset.dimensions.items()}
 
         dset.sync()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ filterwarnings =
     ignore:co_lnotab:DeprecationWarning
     ignore:Passing unrecognized arguments:DeprecationWarning
     ignore:unclosed file <_io\.BufferedReader.*?de421\.bsp:ResourceWarning
+    ignore:numpy.ndarray size changed:RuntimeWarning

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -253,8 +253,8 @@ class Test_Writer:
             x=output.OutputFormat(ncformat='f4', dimensions='mydim')
         )
         w = output.Writer.netcdf(file="", formats=variables)
-        w.write(dict(x=np.array([1.0, 2.0, 3.0])))
-        w.write(dict(x=np.array([4.0, 5.0])))
+        w.write_instance(dict(x=np.array([1.0, 2.0, 3.0])))
+        w.write_instance(dict(x=np.array([4.0, 5.0])))
 
         assert w.paths[0].variables['x'][:].tolist() == [1.0, 2.0, 3.0, 4.0, 5.0]
         assert w.sizes == {'mydim': 5}
@@ -266,10 +266,10 @@ class Test_Writer:
         
         # Write four times with numrec = 2
         w = output.Writer.mf_netcdf(file="", formats=variables, numrec=2)
-        w.write(dict(x=np.array([1, 2, 3])))
-        w.write(dict(x=np.array([4, 5])))
-        w.write(dict(x=np.array([6, 7, 8])))
-        w.write(dict(x=np.array([9])))
+        w.write_instance(dict(x=np.array([1, 2, 3])))
+        w.write_instance(dict(x=np.array([4, 5])))
+        w.write_instance(dict(x=np.array([6, 7, 8])))
+        w.write_instance(dict(x=np.array([9])))
 
         # Read x values
         x_values = []
@@ -285,15 +285,28 @@ class Test_Writer:
         
         # Write two times with numrec = 2; single file
         w = output.Writer.mf_netcdf(file="", formats=variables, numrec=2)
-        w.write(dict(x=np.array([1, 2, 3])))
-        w.write(dict(x=np.array([4, 5])))
+        w.write_instance(dict(x=np.array([1, 2, 3])))
+        w.write_instance(dict(x=np.array([4, 5])))
         assert len(w.paths) == 1
         assert w.paths[0].variables['x'][:].tolist() == [1, 2, 3, 4, 5]
 
         # Write once more; two files
-        w.write(dict(x=np.array([6, 7, 8])))
+        w.write_instance(dict(x=np.array([6, 7, 8])))
         assert len(w.paths) == 2
         assert w.paths[1].variables['x'][:].tolist() == [6, 7, 8]
+
+        w.close()
+
+    def test_mf_netcdf_writer_does_not_split_on_init_writes(self):
+        variables = dict(x=output.OutputFormat(ncformat='f4', dimensions='xd'))
+        
+        # Write three times with numrec = 2; still a single file
+        w = output.Writer.mf_netcdf(file="", formats=variables, numrec=2)
+        w.write_init(dict(x=np.array([1, 2, 3])))
+        w.write_init(dict(x=np.array([4, 5])))
+        w.write_init(dict(x=np.array([6, 7, 8])))
+        assert len(w.paths) == 1
+        assert w.paths[0].variables['x'][:].tolist() == [1, 2, 3, 4, 5, 6, 7, 8]
 
         w.close()
 
@@ -302,16 +315,15 @@ class Test_Writer:
         
         # Write three times with numrec = 2; two files
         w = output.Writer.mf_netcdf(file="", formats=variables, numrec=2)
-        w.write(dict(x=np.array([1, 2, 3])))
-        w.write(dict(x=np.array([4, 5])))
-        w.write(dict(x=np.array([6, 7, 8])))
+        w.write_instance(dict(x=np.array([1, 2, 3])))
+        w.write_instance(dict(x=np.array([4, 5])))
+        w.write_instance(dict(x=np.array([6, 7, 8])))
 
         assert w.sizes['xd'] == 8
 
         w.close()
 
     def test_mf_netcdf_writer_copies_particle_table(self):
-        # 'particle' is a special keyword: These variables should be copied
         variables = dict(x=output.OutputFormat(ncformat='f4', dimensions='xd'))
         
         # Write three times with numrec = 2
@@ -321,9 +333,9 @@ class Test_Writer:
             numrec=2,
             copy_dims=('xd', ),
             )
-        w.write(dict(x=np.array([1, 2, 3])))
-        w.write(dict(x=np.array([4, 5])))
-        w.write(dict(x=np.array([6, 7, 8])))
+        w.write_instance(dict(x=np.array([1, 2, 3])))
+        w.write_instance(dict(x=np.array([4, 5])))
+        w.write_instance(dict(x=np.array([6, 7, 8])))
 
         assert w.paths[0].variables['x'][:].tolist() == [1, 2, 3, 4, 5]
         assert w.paths[1].variables['x'][:].tolist() == [1, 2, 3, 4, 5, 6, 7, 8]
@@ -332,7 +344,6 @@ class Test_Writer:
         w.close()
 
     def test_mf_netcdf_writer_updates_offset_variable(self):
-        # 'particle_instance' is a special keyword: This dimension has an offset variable
         variables = dict(
             x=output.OutputFormat(ncformat='f4', dimensions='xd'),
             xd_offset=output.OutputFormat(ncformat='i4', dimensions='')
@@ -345,9 +356,9 @@ class Test_Writer:
             numrec=2,
             offset_variables={'xd': 'xd_offset'}
         )
-        w.write(dict(x=np.array([1, 2, 3])))
-        w.write(dict(x=np.array([4, 5])))
-        w.write(dict(x=np.array([6, 7, 8])))
+        w.write_instance(dict(x=np.array([1, 2, 3])))
+        w.write_instance(dict(x=np.array([4, 5])))
+        w.write_instance(dict(x=np.array([6, 7, 8])))
 
         assert w.paths[0].variables['xd_offset'][...] == 0
         assert w.paths[1].variables['xd_offset'][...] == 5


### PR DESCRIPTION
Previously, the output was split into many extra files if the release frequency was higher than the output frequency. This has now been fixed.